### PR TITLE
png_do_check_plaette_indexes was ignoring the last byte of each row

### DIFF
--- a/pngtrans.c
+++ b/pngtrans.c
@@ -708,7 +708,7 @@ png_do_check_palette_indexes(png_structrp png_ptr, png_row_infop row_info)
        * forms produced on either GCC or MSVC.
        */
       int padding = PNG_PADBITS(row_info->pixel_depth, row_info->width);
-      png_bytep rp = png_ptr->row_buf + row_info->rowbytes - 1;
+      png_bytep rp = png_ptr->row_buf + row_info->rowbytes;
 
       switch (row_info->bit_depth)
       {


### PR DESCRIPTION
png_do_check_plaette_indexes was ignoring the last byte of each row (in pngtrans.c).

png_do_check_palette() apparently has an off-by-one error in its initialization of its row pointer
("rp") variable, where is fails to take into consideration that png_ptr->row_buf starts with an extra byte that is not pixel data.  The rest of the function seems to take this into consideration.  The patch just deletes a "- 1" in the computation of the initial value of rp.  The resulting code builds and passes "make test", but that is the extent of my testing so far.

Cosmin, if this is the wrong repository for submitting merge requests, for example, if I should use the sourceforge.net git repository (where I submitted a different tiny merge request a few days ago), please feel free to reject this merge request on that basis.  I am basically just trying to determine how I am supposed to submit contributions.  I have other changes to submit, but I am just starting with these small changes first, in order to make sure I am doing the process right, to reduce the amount of unnecessary work that I might cause by following the wrong process.  Thanks in advance for your help with this, and thanks for maintaining libpng.